### PR TITLE
Adds support for gcloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM alpine:3.6
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
+
+ENV GOOGLE_CLOUD_SDK_VERSION 181.0.0
+ENV PATH /root/google-cloud-sdk/bin:$PATH
+
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="mgob" \
       org.label-schema.description="MongoDB backup automation tool" \
@@ -18,6 +22,26 @@ ADD https://dl.minio.io/client/mc/release/linux-amd64/mc /usr/bin
 RUN chmod u+x /usr/bin/mc
 
 WORKDIR /root/
+
+#install gcloud
+# https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/69b7b0031d877600a9146c1111e43bc66b536de7/alpine/Dockerfile
+RUN apk --no-cache add \
+        curl \
+        python \
+        py-crcmod \
+        bash \
+        libc6-compat \
+        openssh-client \
+        git \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    tar xzf google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    ln -s /lib /lib64 && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
+
 COPY mgob    .
 
 VOLUME ["/config", "/storage", "/tmp", "/data"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MGOB is a MongoDB backup automation tool built with golang.
 * schedule backups
 * local backups retention
 * upload to S3 Object Storage (Minio, AWS, Google Cloud)
+* upload to gcloud storage
 * upload to SFTP
 * notifications (Email, Slack)
 * instrumentation with Prometheus
@@ -69,6 +70,10 @@ s3:
   accessKey: "Q3AM3UQ867SPQQA43P2F"
   secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
   api: "S3v4"
+# GCloud upload (optional)
+gcloud:
+  bucket: "backup"
+  keyFilePath: /path/to/service-account.json
 # SFTP upload (optional)
 sftp:
   host: sftp.company.com

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -76,6 +76,15 @@ func Run(plan config.Plan, tmpPath string, storagePath string) (Result, error) {
 		}
 	}
 
+	if plan.GCloud != nil {
+		gCloudOutput, err := gCloudUpload(file, plan)
+		if err != nil {
+			return res, err
+		} else {
+			logrus.WithField("plan", plan.Name).Infof("GCloud upload finished %v", gCloudOutput)
+		}
+	}
+
 	t2 := time.Now()
 	res.Status = 200
 	res.Duration = t2.Sub(t1)

--- a/backup/checks.go
+++ b/backup/checks.go
@@ -32,3 +32,16 @@ func CheckMinioClient() (string, error) {
 
 	return strings.Replace(string(output), "\n", " ", -1), nil
 }
+
+func CheckGCloudClient() (string, error) {
+	output, err := sh.Command("/bin/sh", "-c", "gcloud --version").CombinedOutput()
+	if err != nil {
+		ex := ""
+		if len(output) > 0 {
+			ex = strings.Replace(string(output), "\n", " ", -1)
+		}
+		return "", errors.Wrapf(err, "gcloud failed %v", ex)
+	}
+
+	return strings.Replace(string(output), "\n", " ", -1), nil
+}

--- a/backup/gcloud.go
+++ b/backup/gcloud.go
@@ -1,0 +1,41 @@
+package backup
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/codeskyblue/go-sh"
+	"github.com/pkg/errors"
+	"github.com/stefanprodan/mgob/config"
+)
+
+func gCloudUpload(file string, plan config.Plan) (string, error) {
+
+	register := fmt.Sprintf("gcloud auth activate-service-account --key-file=%v",
+		plan.GCloud.KeyFilePath)
+
+	_, err := sh.Command("/bin/sh", "-c", register).CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "gcloud auth for plan %v failed", plan.Name)
+	}
+
+	upload := fmt.Sprintf("gsutil cp %v gs://%v",
+		file, plan.GCloud.Bucket)
+
+	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
+	output := ""
+	if len(result) > 0 {
+		output = strings.Replace(string(result), "\n", " ", -1)
+	}
+
+	if err != nil {
+		return "", errors.Wrapf(err, "GCloud uploading %v to gs://%v failed %v", file, plan.GCloud.Bucket, output)
+	}
+
+	if strings.Contains(output, "<ERROR>") {
+		return "", errors.Errorf("GCloud upload failed %v", output)
+	}
+
+	return strings.Replace(output, "\n", " ", -1), nil
+}

--- a/config/plan.go
+++ b/config/plan.go
@@ -15,6 +15,7 @@ type Plan struct {
 	Target    Target    `yaml:"target"`
 	Scheduler Scheduler `yaml:"scheduler"`
 	S3        *S3       `yaml:"s3"`
+	GCloud    *GCloud   `yaml:"gcloud"`
 	SFTP      *SFTP     `yaml:"sftp"`
 	SMTP      *SMTP     `yaml:"smtp"`
 	Slack     *Slack    `yaml:"slack"`
@@ -40,6 +41,11 @@ type S3 struct {
 	API       string `yaml:"api"`
 	SecretKey string `yaml:"secretKey"`
 	URL       string `yaml:"url"`
+}
+
+type GCloud struct {
+	Bucket string `yaml:"bucket"`
+	KeyFilePath string `yaml:"keyFilePath"`
 }
 
 type SFTP struct {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ func main() {
 	}
 	logrus.Info(info)
 
+	info, err = backup.CheckGCloudClient()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Info(info)
+
 	plans, err := config.LoadPlans(appConfig.ConfigPath)
 	if err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
Hello,

I did not see any Contributors Guidelines so please let me know if there's anything I can adjust to your liking.

This PR adds support for using `gcloud`/`gsutil` to backup to a GCP Storage Bucket using a service account. The reason I went this way was because the [Google Storage XML API](https://cloud.google.com/storage/docs/migrating), makes you create an actual account and enable `Interoperability` on the entire project and this was not something we wanted to do. 

The `Dockerfile` additions were take directly from the GoogleCloudPlatform's alpine docker image.

I am not very proficient in go so please tell me if you would like anything changed.

Thank you for this great project!