### PR TITLE
Add support for backing up all databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ target:
   host: "172.18.7.21"
   # mongodb port
   port: 27017
-  # mongodb database name
+  # mongodb database name, leave blank to backup all databases
   database: "test"
   # leave blank if auth is not enabled
   username: "admin"

--- a/backup/local.go
+++ b/backup/local.go
@@ -16,8 +16,11 @@ func dump(plan config.Plan, tmpPath string, ts time.Time) (string, string, error
 	archive := fmt.Sprintf("%v/%v-%v.gz", tmpPath, plan.Name, ts.Unix())
 	log := fmt.Sprintf("%v/%v-%v.log", tmpPath, plan.Name, ts.Unix())
 
-	dump := fmt.Sprintf("mongodump --archive=%v --gzip --host %v --port %v --db %v ",
-		archive, plan.Target.Host, plan.Target.Port, plan.Target.Database)
+	dump := fmt.Sprintf("mongodump --archive=%v --gzip --host %v --port %v ",
+		archive, plan.Target.Host, plan.Target.Port)
+	if plan.Target.Database != "" {
+		dump += fmt.Sprintf("--db %v ", plan.Target.Database)
+	}
 	if plan.Target.Username != "" && plan.Target.Password != "" {
 		dump += fmt.Sprintf("-u %v -p %v", plan.Target.Username, plan.Target.Password)
 	}


### PR DESCRIPTION
This PR adds support for backing up all databases on the server. If no --db parameter is supplied on mongodump command line it will backup all dbs by default. The code adds --db parameter only if target.database is not empty. So leaving target.database blank will backup everything. Fixes #8 