### PR TITLE
Add support for sending custom params to mongodump (eg. SSL support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ target:
   # leave blank if auth is not enabled
   username: "admin"
   password: "secret"
+  # add custom params to mongodump (eg. SSL support), leave blank if not needed
+  params: "--ssl"
 # S3 upload (optional)
 s3:
   url: "https://play.minio.io:9000"

--- a/backup/local.go
+++ b/backup/local.go
@@ -22,7 +22,10 @@ func dump(plan config.Plan, tmpPath string, ts time.Time) (string, string, error
 		dump += fmt.Sprintf("--db %v ", plan.Target.Database)
 	}
 	if plan.Target.Username != "" && plan.Target.Password != "" {
-		dump += fmt.Sprintf("-u %v -p %v", plan.Target.Username, plan.Target.Password)
+		dump += fmt.Sprintf("-u %v -p %v ", plan.Target.Username, plan.Target.Password)
+	}
+	if plan.Target.Params != "" {
+		dump += fmt.Sprintf("%v", plan.Target.Params)
 	}
 
 	output, err := sh.Command("/bin/sh", "-c", dump).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()

--- a/config/plan.go
+++ b/config/plan.go
@@ -27,6 +27,7 @@ type Target struct {
 	Password string `yaml:"password"`
 	Port     int    `yaml:"port"`
 	Username string `yaml:"username"`
+	Params   string `yaml:"params"`
 }
 
 type Scheduler struct {


### PR DESCRIPTION
This PR adds support for sending custom params to mongodump (eg. SSL support) while backuping the target.
The code adds custom params to mongodump command-line only if target.params is not empty. So leaving target.params blank won't change anything. Hope this helps to fix #12 