### PR TITLE
Add support for environment variable expansion within plan configurat…

### DIFF
--- a/config/plan.go
+++ b/config/plan.go
@@ -102,6 +102,9 @@ func LoadPlan(dir string, name string) (Plan, error) {
 		return plan, errors.Wrapf(err, "Reading %v failed", planPath)
 	}
 
+	// expand environment variables
+	data = []byte(os.ExpandEnv(string(data)))  
+
 	if err := yaml.Unmarshal(data, &plan); err != nil {
 		return plan, errors.Wrapf(err, "Parsing %v failed", planPath)
 	}


### PR DESCRIPTION
Required to keep database passwords away from configuration.
Solution borrowed from https://mtyurt.net/post/go-using-environment-variables-in-configuration-files.html