### PR TITLE
Added "Uri" option in target (fixes #64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/stefanprodan/mgob
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.version=$APP_VERSION" \
     -a -installsuffix cgo -o mgob github.com/stefanprodan/mgob
 
-FROM alpine:edge
+FROM alpine:latest
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/config/plan.go
+++ b/config/plan.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type Plan struct {
@@ -25,6 +25,7 @@ type Plan struct {
 type Target struct {
 	Database string `yaml:"database"`
 	Host     string `yaml:"host"`
+	Uri      string `yaml:"uri"`
 	Password string `yaml:"password"`
 	Port     int    `yaml:"port"`
 	Username string `yaml:"username"`
@@ -51,7 +52,7 @@ type GCloud struct {
 }
 
 type Azure struct {
-	ContainerName string `yaml:"containerName"`
+	ContainerName    string `yaml:"containerName"`
 	ConnectionString string `yaml:"connectionString"`
 }
 


### PR DESCRIPTION
Mongodump command line supports uri -- when using Uri, all other
parameters: host, port, user, password are not used.