### PR TITLE
Minor sophisticate s3 url in helm values

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -54,7 +54,7 @@ configMap:
         retention: 7
         timeout: 60
       s3:
-        url: "https://s3.amazonaws.com"
+        url: "https://s3.dualstack.us-east-1.amazonaws.com"
         bucket: "my-db-backups"
         accessKey: "ABCDEFGHIJKLMNOPQRST"
         secretKey: "be0da49b599b24115c7f53c92c729cbb2c8a17e5"
@@ -79,7 +79,7 @@ configMap:
         retention: 7
         timeout: 60
       s3:
-        url: "https://s3.amazonaws.com"
+        url: "https://s3.dualstack.us-east-1.amazonaws.com"
         bucket: "my-db-backups"
         accessKey: "ABCDEFGHIJKLMNOPQRST"
         secretKey: "be0da49b599b24115c7f53c92c729cbb2c8a17e5"


### PR DESCRIPTION
It will save user's time in case they have s3 bucket in another region then default ( us-east-1 ).
https://docs.aws.amazon.com/general/latest/gr/rande.html 
```
When you use an endpoint with no Region, AWS routes the Amazon EC2 request to US East (N. Virginia) (us-east-1), which is the default Region for API calls.
```
