### PR TITLE
Pin alpine to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
         -a -installsuffix cgo \
         -o mgob github.com/stefanprodan/mgob/cmd/mgob
 
-FROM alpine:latest
+FROM alpine:3.9
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Fixes #87 by resolving the following error on `alpine:latest`
```
ERROR: unsatisfiable constraints:
  mongodb-tools (missing):
    required by: world[mongodb-tools=4.0.5-r0]
```