### PR TITLE
Resource DaemonSet is deprecated in Kubernetes API apps/v1beta2

### DIFF
--- a/k8s/mongo-ds.yaml
+++ b/k8s/mongo-ds.yaml
@@ -1,6 +1,6 @@
 ---
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: startup-script
   namespace: db


### PR DESCRIPTION
DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.

ref: https://docs.okd.io/latest/rest_api/apis-apps/v1beta2.DaemonSet.html