### PR TITLE
Add rclone as upload mech

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ RUN apk add --no-cache ca-certificates tzdata mongodb-tools=${MONGODB_TOOLS_VERS
 ADD https://dl.minio.io/client/mc/release/linux-amd64/mc /usr/bin
 RUN chmod u+x /usr/bin/mc
 
+ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /tmp
+RUN cd /tmp \
+  && unzip rclone-current-linux-amd64.zip \
+  && cp rclone-*-linux-amd64/rclone /usr/bin/ \
+  && chmod u+x /usr/bin/rclone
+
 WORKDIR /root/
 
 #install gcloud

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MGOB is a MongoDB backup automation tool built with Go.
 * upload to S3 Object Storage (Minio, AWS, Google Cloud, Azure)
 * upload to gcloud storage
 * upload to SFTP
+* upload to any [Rclone](https://rclone.org/) supported storage
 * notifications (Email, Slack)
 * instrumentation with Prometheus
 * http file server for local backups and logs
@@ -94,6 +95,11 @@ gcloud:
 azure:
   containerName: "backup"
   connectionString: "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+# Rclone upload (optional)
+rclone:
+  bucket: "my-backup-bucket"
+  # See https://rclone.org/docs/ for details on how to configure rclone
+  configFilePath: /etc/rclone.conf
 # SFTP upload (optional)
 sftp:
   host: sftp.company.com

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -99,11 +99,20 @@ func Run(plan config.Plan, tmpPath string, storagePath string) (Result, error) {
 	}
 
 	if plan.Azure != nil {
-		azureOutout, err := azureUpload(file, plan)
+		azureOutput, err := azureUpload(file, plan)
 		if err != nil {
 			return res, err
 		} else {
-			log.WithField("plan", plan.Name).Infof("Azure upload finished %v", azureOutout)
+			log.WithField("plan", plan.Name).Infof("Azure upload finished %v", azureOutput)
+		}
+	}
+
+	if plan.Rclone != nil {
+		rcloneOutput, err := rcloneUpload(file, plan)
+		if err != nil {
+			return res, err
+		} else {
+			log.WithField("plan", plan.Name).Infof("Rclone upload finished %v", rcloneOutput)
 		}
 	}
 

--- a/pkg/backup/rclone.go
+++ b/pkg/backup/rclone.go
@@ -1,0 +1,33 @@
+package backup
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/codeskyblue/go-sh"
+	"github.com/pkg/errors"
+
+	"github.com/stefanprodan/mgob/pkg/config"
+)
+
+func rcloneUpload(file string, plan config.Plan) (string, error) {
+
+	fileName := filepath.Base(file)
+
+	upload := fmt.Sprintf("rclone copy %v %v:%v/%v",
+		file, plan.Name, plan.Rclone.Bucket, fileName)
+
+	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
+	output := ""
+	if len(result) > 0 {
+		output = strings.Replace(string(result), "\n", " ", -1)
+	}
+
+	if err != nil {
+		return "", errors.Wrapf(err, "Rclone uploading %v to %v:%v failed %v", file, plan.Name, plan.Rclone.Bucket, output)
+	}
+
+	return strings.Replace(output, "\n", " ", -1), nil
+}

--- a/pkg/backup/rclone.go
+++ b/pkg/backup/rclone.go
@@ -16,8 +16,8 @@ func rcloneUpload(file string, plan config.Plan) (string, error) {
 
 	fileName := filepath.Base(file)
 
-	upload := fmt.Sprintf("rclone copy %v %v:%v/%v",
-		file, plan.Name, plan.Rclone.Bucket, fileName)
+	upload := fmt.Sprintf("rclone --config=\"%v\" copy %v %v:%v/%v",
+		plan.Rclone.ConfigFilePath, plan.Name, plan.Rclone.Bucket, fileName)
 
 	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
 	output := ""

--- a/pkg/config/plan.go
+++ b/pkg/config/plan.go
@@ -16,6 +16,7 @@ type Plan struct {
 	Scheduler Scheduler `yaml:"scheduler"`
 	S3        *S3       `yaml:"s3"`
 	GCloud    *GCloud   `yaml:"gcloud"`
+	Rclone    *Rclone   `yaml:"rclone"`
 	Azure     *Azure    `yaml:"azure"`
 	SFTP      *SFTP     `yaml:"sftp"`
 	SMTP      *SMTP     `yaml:"smtp"`
@@ -49,6 +50,11 @@ type S3 struct {
 type GCloud struct {
 	Bucket      string `yaml:"bucket"`
 	KeyFilePath string `yaml:"keyFilePath"`
+}
+
+type Rclone struct {
+	Bucket         string `yaml:"bucket"`
+	ConfigFilePath string `yaml:"configFilePath"`
 }
 
 type Azure struct {


### PR DESCRIPTION
We wanted to use mgob with Alibaba OSS, but it seems Minio Client doesn't handle the uploading correctly (verified this manually as well). We have been using rclone in the past, and it is a swiss-army-knife in cloud storage.

So I added a way to use rclone as an uploadFile method. 