### PR TITLE
Fix rclone upload and add config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ rclone:
   bucket: "my-backup-bucket"
   # See https://rclone.org/docs/ for details on how to configure rclone
   configFilePath: /etc/rclone.conf
-  sectionName: "myrclonesection"
+  configSection: "myrclonesection"
 # SFTP upload (optional)
 sftp:
   host: sftp.company.com

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ rclone:
   bucket: "my-backup-bucket"
   # See https://rclone.org/docs/ for details on how to configure rclone
   configFilePath: /etc/rclone.conf
+  sectionName: "myrclonesection"
 # SFTP upload (optional)
 sftp:
   host: sftp.company.com

--- a/pkg/backup/rclone.go
+++ b/pkg/backup/rclone.go
@@ -22,7 +22,7 @@ func rcloneUpload(file string, plan config.Plan) (string, error) {
 	}
 
 	upload := fmt.Sprintf("rclone --config=\"%v\" copy %v %v:%v/%v",
-		plan.Rclone.ConfigFilePath, file, plan.Rclone.ConfigSection, plan.Rclone.Bucket, fileName)
+		plan.Rclone.ConfigFilePath, file, sectionName, plan.Rclone.Bucket, fileName)
 
 	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
 	output := ""

--- a/pkg/backup/rclone.go
+++ b/pkg/backup/rclone.go
@@ -16,8 +16,13 @@ func rcloneUpload(file string, plan config.Plan) (string, error) {
 
 	fileName := filepath.Base(file)
 
+	sectionName := plan.Rclone.ConfigSection
+	if "" == sectionName {
+		sectionName = plan.Name
+	}
+
 	upload := fmt.Sprintf("rclone --config=\"%v\" copy %v %v:%v/%v",
-		plan.Rclone.ConfigFilePath, plan.Name, plan.Rclone.Bucket, fileName)
+		plan.Rclone.ConfigFilePath, file, plan.Rclone.ConfigSection, plan.Rclone.Bucket, fileName)
 
 	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
 	output := ""

--- a/pkg/backup/rclone.go
+++ b/pkg/backup/rclone.go
@@ -16,13 +16,13 @@ func rcloneUpload(file string, plan config.Plan) (string, error) {
 
 	fileName := filepath.Base(file)
 
-	sectionName := plan.Rclone.ConfigSection
-	if "" == sectionName {
-		sectionName = plan.Name
+	configSection := plan.Rclone.ConfigSection
+	if "" == configSection {
+		configSection = plan.Name
 	}
 
 	upload := fmt.Sprintf("rclone --config=\"%v\" copy %v %v:%v/%v",
-		plan.Rclone.ConfigFilePath, file, sectionName, plan.Rclone.Bucket, fileName)
+		plan.Rclone.ConfigFilePath, file, configSection, plan.Rclone.Bucket, fileName)
 
 	result, err := sh.Command("/bin/sh", "-c", upload).SetTimeout(time.Duration(plan.Scheduler.Timeout) * time.Minute).CombinedOutput()
 	output := ""

--- a/pkg/config/plan.go
+++ b/pkg/config/plan.go
@@ -55,6 +55,7 @@ type GCloud struct {
 type Rclone struct {
 	Bucket         string `yaml:"bucket"`
 	ConfigFilePath string `yaml:"configFilePath"`
+	ConfigSection  string `yaml:"configSection"`
 }
 
 type Azure struct {


### PR DESCRIPTION
There was a small bug in the rclone upload.

And as my colleagues started implementing it, they struggled with the default usage of `plan.Name` as the sectionname in the `rclone.conf` file. I guess others might have questions around this as well, so I added the sectionName as an option in the config. 