### PR TITLE
Disable smtp auth part when username is empty

### DIFF
--- a/pkg/notifier/smtp.go
+++ b/pkg/notifier/smtp.go
@@ -18,7 +18,14 @@ func sendEmailNotification(subject string, body string, config *config.SMTP) err
 		body + "\r\n"
 
 	addr := fmt.Sprintf("%v:%v", config.Server, config.Port)
-	auth := smtp.PlainAuth("", config.Username, config.Password, config.Server)
+
+	// auth is set to nil by default
+	// workaround for error given if auth is disabled on the smtp server
+	// notifier error: "smtp: server doesn't support AUTH"
+	var auth smtp.Auth
+	if config.Username != "" {
+		auth = smtp.PlainAuth("", config.Username, config.Password, config.Server)
+	}
 
 	if err := smtp.SendMail(addr, auth, config.From, config.To, []byte(msg)); err != nil {
 		return errors.Wrapf(err, "sending email notification failed")


### PR DESCRIPTION
Hi,
I'm having trouble on the smtp notifier part.
My smtp servers does not need any authentication part, due to that, i'm having errors when trying to send mails at the end of the backup:

~~~
time="2020-05-07T09:15:00Z" level=info msg="Backup started" plan=default
time="2020-05-07T09:15:00Z" level=info msg="new dump" archive=/tmp/default-1588842900.gz err="<nil>" mlog=/tmp/default-1588842900.log planDir=/storage/default
time="2020-05-07T09:15:00Z" level=info msg="Backup finished in 172.445231ms archive default-1588842900.gz size 2.0 kB" plan=default
time="2020-05-07T09:15:00Z" level=error msg="Notifier failed sending email notification failed: smtp: server doesn't support AUTH" plan=default
time="2020-05-07T09:15:00Z" level=info msg="Next run at 2020-05-08 09:15:00 +0000 UTC" plan=default
~~~

Maybe it should be interesting to set to nil the auth part in the smtp method, it works for me.

Best regards,


Thanks for your tool ^^