### PR TITLE
Adds `host` option

### DIFF
--- a/cmd/mgob/mgob.go
+++ b/cmd/mgob/mgob.go
@@ -71,6 +71,11 @@ func main() {
 			Usage: "HTTP port to listen on",
 			Value: 8090,
 		},
+		cli.StringFlag{
+			Name:  "Host,h",
+			Usage: "HTTP host to listen on",
+			Value: "",
+		},
 		cli.BoolFlag{
 			Name:  "JSONLog,j",
 			Usage: "logs in JSON format",

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -47,7 +47,7 @@ func (s *HttpServer) Start(version string) {
 
 	FileServer(r, "/storage", http.Dir(s.Config.StoragePath))
 
-	log.Error(http.ListenAndServe(fmt.Sprintf(":%v", s.Config.Port), r))
+	log.Error(http.ListenAndServe(fmt.Sprintf("%s:%v", s.Config.Host, s.Config.Port), r))
 }
 
 func FileServer(r chi.Router, path string, root http.FileSystem) {

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -3,6 +3,7 @@ package config
 type AppConfig struct {
 	LogLevel    string `json:"log_level"`
 	JSONLog     bool   `json:"json_log"`
+	Host        string `json:"host"`
 	Port        int    `json:"port"`
 	ConfigPath  string `json:"config_path"`
 	StoragePath string `json:"storage_path"`


### PR DESCRIPTION
This allows to bind to a specific host (and port, but that already existed).

closes #136 