### PR TITLE
Fix host binding flags

### DIFF
--- a/cmd/mgob/mgob.go
+++ b/cmd/mgob/mgob.go
@@ -68,12 +68,12 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:  "Port,p",
-			Usage: "HTTP port to listen on",
+			Usage: "Port to bind the HTTP server on",
 			Value: 8090,
 		},
 		cli.StringFlag{
-			Name:  "Host,h",
-			Usage: "HTTP host to listen on",
+			Name:  "Bind,b",
+			Usage: "Host to bind the HTTP server on",
 			Value: "",
 		},
 		cli.BoolFlag{
@@ -95,6 +95,7 @@ func start(c *cli.Context) error {
 	appConfig.LogLevel = c.String("LogLevel")
 	appConfig.JSONLog = c.Bool("JSONLog")
 	appConfig.Port = c.Int("Port")
+	appConfig.Host = c.String("Bind")
 	appConfig.ConfigPath = c.String("ConfigPath")
 	appConfig.StoragePath = c.String("StoragePath")
 	appConfig.TmpPath = c.String("TmpPath")


### PR DESCRIPTION
My apologies, I introduced more bugs than features in the last fast patch. After testing this now, it seems to work correct

```
tcp        0      0 127.0.0.1:8090          0.0.0.0:*               LISTEN      1/mgob
```

- `h` is reserved
- attach the value to the correct config-parameter